### PR TITLE
Add SECURITY.md for vulnerability disclosure

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do not open a public issue.** Security vulnerabilities should be reported privately.
+
+Please email **andy@psdn.ai** with:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Affected versions
+- Any potential impact you've identified
+
+## Response Timeline
+
+| Step | Timeframe |
+|------|-----------|
+| Acknowledge receipt | Within 48 hours |
+| Initial assessment | Within 7 days |
+| Fix or mitigation plan | Within 30 days |
+| Public disclosure | After fix is released (max 90 days) |
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest on `main` | Yes |
+| Older releases | No |
+
+## Scope
+
+This policy applies to all code in the `PSDN-AI/nexus-skills` repository, including:
+
+- Scanner scripts
+- Skill definitions
+- Templates and examples
+
+## Credit
+
+We appreciate responsible disclosure and will credit reporters in the fix announcement unless they prefer to remain anonymous.


### PR DESCRIPTION
## Summary
- Adds SECURITY.md with private vulnerability reporting instructions
- Identified as missing by the repo-public-readiness scanner self-scan
- Required before making the repo public

## Test plan
- [ ] Verify SECURITY.md renders correctly on GitHub
- [ ] Confirm GitHub "Security" tab picks up the file