### PR TITLE
Update project docs for current state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,19 +9,19 @@ A Skill is a **knowledge document first, executable second**.
 ## Three-Layer Consumption Model
 
 ```
-┌────────────────────────────────────────────────────┐
-│  Layer 3: CI/CD (GitHub Actions)                   │
-│  uses: PSDN-AI/nexus-skills/skills/...@v0.0.1      │
-│  → Automated pipeline integration via action.yml   │
-├────────────────────────────────────────────────────┤
-│  Layer 2: CLI (Bash Scripts)                       │
-│  ./scripts/run_scan.sh /path/to/repo                │
-│  → Direct execution by humans or agents            │
-├────────────────────────────────────────────────────┤
-│  Layer 1: AI Knowledge (SKILL.md)                  │
-│  AI reads instructions → understands task → acts   │
-│  → Any AI agent can consume this, vendor-neutral   │
-└────────────────────────────────────────────────────┘
++----------------------------------------------------+
+|  Layer 3: CI/CD (GitHub Actions)                   |
+|  uses: PSDN-AI/nexus-skills/skills/...@v0.0.1      |
+|  -> Automated pipeline integration via action.yml  |
++----------------------------------------------------+
+|  Layer 2: CLI (Bash Scripts)                       |
+|  ./scripts/run_scan.sh /path/to/repo               |
+|  -> Direct execution by humans or agents           |
++----------------------------------------------------+
+|  Layer 1: AI Knowledge (SKILL.md)                  |
+|  AI reads instructions -> understands task -> acts |
+|  -> Any AI agent can consume this, vendor-neutral  |
++----------------------------------------------------+
 ```
 
 Each layer wraps the one below it. SKILL.md is always the source of truth.
@@ -91,4 +91,4 @@ No package manager, no git submodules. Git + URL is the distribution mechanism.
 
 ## Discovery
 
-Agent products discover Skills by scanning the `skills/` directory for `SKILL.md` files. Each `SKILL.md` contains YAML frontmatter with `name` and `description` fields that agents parse at startup for discovery.
+Agent products discover Skills by scanning the `skills/` directory for `SKILL.md` files. Each `SKILL.md` contains YAML frontmatter with `name` and `description` fields that agents parse at startup for discovery. See the [Agent Skills standard](https://agentskills.io/specification) for details.

--- a/README.md
+++ b/README.md
@@ -2,26 +2,26 @@
 
 ## What is this?
 
-A curated marketplace of reusable AI Agent Skills for Infrastructure, DevOps, and Automation. Each Skill is a standardized, battle-tested knowledge module that any AI Agent can use.
+A curated marketplace of reusable AI Agent Skills for Infrastructure, DevOps, and Automation. Each Skill is a standardized, battle-tested knowledge module that any AI Agent can use. Skills follow the [Agent Skills standard](https://agentskills.io) — the open format supported by 30+ agent products.
 
 ## How Skills Work
 
 Every Skill can be consumed at three layers:
 
 ```
-┌────────────────────────────────────────────────────┐
-│  Layer 3: CI/CD (GitHub Actions)                   │
-│  uses: PSDN-AI/nexus-skills/skills/...@v0.0.1      │
-│  → Automated pipeline integration via action.yml   │
-├────────────────────────────────────────────────────┤
-│  Layer 2: CLI (Bash Scripts)                       │
-│  ./scripts/run_scan.sh /path/to/repo                │
-│  → Direct execution by humans or agents            │
-├────────────────────────────────────────────────────┤
-│  Layer 1: AI Knowledge (SKILL.md)                  │
-│  AI reads instructions → understands task → acts   │
-│  → Any AI agent can consume this, vendor-neutral   │
-└────────────────────────────────────────────────────┘
++----------------------------------------------------+
+|  Layer 3: CI/CD (GitHub Actions)                   |
+|  uses: PSDN-AI/nexus-skills/skills/...@v0.0.1      |
+|  -> Automated pipeline integration via action.yml  |
++----------------------------------------------------+
+|  Layer 2: CLI (Bash Scripts)                       |
+|  ./scripts/run_scan.sh /path/to/repo               |
+|  -> Direct execution by humans or agents           |
++----------------------------------------------------+
+|  Layer 1: AI Knowledge (SKILL.md)                  |
+|  AI reads instructions -> understands task -> acts |
+|  -> Any AI agent can consume this, vendor-neutral  |
++----------------------------------------------------+
 ```
 
 ## Prerequisites


### PR DESCRIPTION
## Summary

### CLAUDE.md (386 → 247 lines)
- Update directory structure: `scripts/`, `assets/`, `references/`, `tests/`; remove `catalog.yaml`, `metadata.yaml`
- Add Agent Skills standard reference and YAML frontmatter requirement to Skill Standard (Part 3.1)
- Replace duplicated scan spec (~120 lines) with pointers to SKILL.md and references/
- Mark Phase 1 as complete, remove outdated file references

### README.md
- Add Agent Skills standard mention in project description

### ARCHITECTURE.md
- Replace catalog.yaml Discovery section with standard directory-scanning model

## Test plan

- [x] All 116 tests pass
- [x] CLAUDE.md directory structure matches actual repo layout
- [x] No references to deleted files (metadata.yaml, catalog.yaml, scanner/)

**Note**: This PR should be merged after #16 to avoid conflicts on ARCHITECTURE.md Discovery section.