### PR TITLE
Add Claude Code plugin marketplace support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "name": "nexus-skills",
+  "owner": {
+    "name": "PSDN-AI"
+  },
+  "metadata": {
+    "description": "Reusable AI Agent Skills for Infrastructure, DevOps, and Automation",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "repo-public-readiness",
+      "source": "./skills/repo-public-readiness",
+      "description": "Scans repositories for secrets, code quality issues, missing documentation, and compliance problems before making them public",
+      "version": "0.1.0",
+      "license": "MIT",
+      "keywords": ["security", "secrets", "compliance", "documentation", "code-quality", "open-source"],
+      "category": "security",
+      "homepage": "https://github.com/PSDN-AI/nexus-skills",
+      "repository": "https://github.com/PSDN-AI/nexus-skills"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Every Skill can be consumed at three layers:
 
 ## Quick Start
 
+### Claude Code (Plugin Marketplace)
+
+```bash
+/plugin marketplace add PSDN-AI/nexus-skills
+/plugin install repo-public-readiness@nexus-skills
+```
+
 ### Layer 2: CLI
 
 ```bash

--- a/skills/repo-public-readiness/.claude-plugin/plugin.json
+++ b/skills/repo-public-readiness/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "repo-public-readiness",
+  "description": "Scans repositories for secrets, code quality issues, missing documentation, and compliance problems before making them public",
+  "version": "0.1.0",
+  "author": {
+    "name": "PSDN-AI"
+  }
+}


### PR DESCRIPTION
## Summary

- Add `.claude-plugin/marketplace.json` at repo root for marketplace registration
- Add `skills/repo-public-readiness/.claude-plugin/plugin.json` for per-skill plugin metadata
- Update README.md with plugin marketplace installation as the first Quick Start option

Users can now install skills with:
```bash
/plugin marketplace add PSDN-AI/nexus-skills
/plugin install repo-public-readiness@nexus-skills
```

Instead of manual git clone + symlink.

## Reference

Follows the same pattern as [piplabs/story-skills](https://github.com/piplabs/story-skills).