### PR TITLE
docs: Add REFERENCES.md for curated external resources

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -1,0 +1,21 @@
+# References
+
+Curated external resources relevant to the Nexus Skills ecosystem.
+
+## Skill Authoring and Testing
+
+| Resource | Summary |
+|----------|---------|
+| [Improving Skill-Creator: Test, Measure, and Refine Agent Skills](https://claude.com/blog/improving-skill-creator-test-measure-and-refine-agent-skills) | Evaluation framework for testing, benchmarking, and A/B comparing Agent Skills — covers pass-rate tracking, multi-agent parallel evals, and description optimization. |
+
+## Agent Architecture
+
+_No entries yet._
+
+## DevOps and Infrastructure
+
+_No entries yet._
+
+## Industry Standards
+
+_No entries yet._


### PR DESCRIPTION
## Summary
- Adds `REFERENCES.md` to centralize curated external references relevant to the Nexus Skills ecosystem
- Includes the Anthropic skill-creator eval guide as the first entry
- Pre-defines categories: Skill Authoring and Testing, Agent Architecture, DevOps and Infrastructure, Industry Standards

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm all links resolve