### PR TITLE
docs: Add missing skills to README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ git clone https://github.com/PSDN-AI/nexus-skills.git
 
 | Skill | Category | Description |
 |-------|----------|-------------|
-| [repo-audit](skills/repo-audit/) | Security & Compliance | Scan for secrets, quality issues, and compliance problems before going public |
 | [prd-decompose](skills/prd-decompose/) | Product Engineering | Decompose a PRD into domain-specific specs for AI Agent consumption |
+| [spec-plan](skills/spec-plan/) | Product Engineering | Convert a domain spec into an executable task graph with dependency ordering and parallelization |
+| [agent-launcher](skills/agent-launcher/) | Product Engineering | Execute a task graph with isolated sub-agents, dependency enforcement, and run reports |
 | [gha-create](skills/gha-create/) | CI/CD & DevOps | Generate GitHub Actions workflows with elite security and efficiency practices |
+| [repo-audit](skills/repo-audit/) | Security & Compliance | Scan for secrets, quality issues, and compliance problems before going public |
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Add `agent-launcher` and `spec-plan` to the Available Skills table in README
- Reorder table by pipeline flow (prd-decompose -> spec-plan -> agent-launcher) followed by other skills

## Test plan

- [ ] Verify all 5 skills are listed in the README table
- [ ] Verify links point to correct skill directories
- [ ] Verify descriptions match SKILL.md frontmatter