### PR TITLE
feat: Add eval framework specification (#35)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Standard skill layout (recommended):
 - `assets/` for templates or data files
 - `examples/` for expected outputs
 - `tests/` with `run_tests.sh` as entry point
+- `evals/` with `eval_*.yaml` eval cases
 - `action.yml` for GitHub Actions integration
 
 ## Build, Test, and Development Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ Lints test scripts with relaxed severity.
 - `bash -n skills/<skill-name>/scripts/*.sh`  
 Fast syntax check when `shellcheck` is unavailable.
 
+Evals (`evals/eval_*.yaml`) are **not** run in CI. They require an LLM and are executed manually. See `EVAL_SPEC.md` for the format and running instructions.
+
 ## Coding Style & Naming Conventions
 Use portable Bash (`#!/usr/bin/env bash`) with `set -euo pipefail`. Scripts must accept target paths as arguments; do not hardcode local paths.
 Require Bash 4.0+ when associative arrays are used.  

--- a/EVAL_SPEC.md
+++ b/EVAL_SPEC.md
@@ -1,0 +1,346 @@
+# Eval Specification
+
+This document defines the YAML format for agent-effectiveness evaluations in Nexus Skills. Evals measure whether a Skill **as a whole** produces good outcomes when an agent uses it --- they complement `tests/`, which validate script correctness.
+
+Inspired by [Anthropic's skill-creator eval guide](https://claude.com/blog/improving-skill-creator-test-measure-and-refine-agent-skills).
+
+---
+
+## Table of Contents
+
+- [Tests vs Evals](#tests-vs-evals)
+- [YAML Schema](#yaml-schema)
+- [Field Reference](#field-reference)
+- [Writing Good Prompts](#writing-good-prompts)
+- [Writing Good Success Criteria](#writing-good-success-criteria)
+- [Tag Taxonomy](#tag-taxonomy)
+- [Examples](#examples)
+
+---
+
+## Tests vs Evals
+
+| Property | `tests/` | `evals/` |
+|----------|----------|----------|
+| What it validates | Script correctness | Skill effectiveness |
+| Deterministic? | Yes | No --- LLM output varies |
+| Runs in CI? | Yes | No --- requires an LLM |
+| Requires LLM? | No | Yes |
+| File pattern | `test_*.sh` | `eval_*.yaml` |
+| Entry point | `run_tests.sh` | Manual or eval harness |
+| Pass/fail criteria | Exit code | Human or LLM judgment against `expected` |
+| Typical runtime | Seconds | Minutes |
+
+Both directories are optional. Skills with scripts should have `tests/`. All non-trivial Skills should have `evals/`.
+
+---
+
+## YAML Schema
+
+### Minimal Example
+
+```yaml
+prompt: |
+  Scan the repository at /tmp/test-repo for secrets and
+  generate a readiness report.
+expected:
+  - "Report contains an overall READY or NOT READY verdict"
+  - "All five scan dimensions are listed in the summary table"
+```
+
+### Full Example
+
+```yaml
+prompt: |
+  Scan the repository at /tmp/test-repo for secrets and
+  generate a readiness report.
+description: >
+  Verify that the scanner produces a complete report with correct
+  verdicts when pointed at a clean repository.
+tags:
+  - basic
+  - happy-path
+context_files:
+  - skills/repo-audit/SKILL.md
+  - skills/repo-audit/references/SCAN_SPEC.md
+setup: |
+  mkdir -p /tmp/test-repo
+  cd /tmp/test-repo && git init
+  echo "# Hello" > README.md && echo "MIT" > LICENSE
+  git add -A && git commit -m "init"
+expected:
+  - "Report contains an overall READY verdict"
+  - "All five scan dimensions appear in the summary table"
+  - "No CRITICAL or HIGH findings are reported"
+expected_behavior:
+  verdict: READY
+  dimensions_present:
+    - Security
+    - Code Quality
+    - Documentation
+    - Repo Hygiene
+    - Legal & Compliance
+  critical_findings: 0
+  high_findings: 0
+difficulty: basic
+model_agnostic: true
+notes: >
+  The clean repo may still produce LOW findings for missing
+  CONTRIBUTING.md or CHANGELOG.md depending on the scan spec version.
+```
+
+---
+
+## Field Reference
+
+### Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `prompt` | string | The prompt to give the agent. Should be self-contained --- an evaluator pastes this into an agent session verbatim. |
+| `expected` | list of strings | Success criteria in plain English. Each item is one pass/fail criterion the evaluator checks against the agent's output. |
+
+### Optional Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `description` | string | --- | Human-readable summary of what this eval tests and why. |
+| `tags` | list of strings | `[]` | Classification tags from the [tag taxonomy](#tag-taxonomy). |
+| `context_files` | list of strings | `[]` | Paths (relative to repo root) the agent should load before executing. |
+| `setup` | string | --- | Shell commands to run before the eval to prepare the environment (create temp repos, seed data, etc.). |
+| `expected_behavior` | map | --- | Structured, machine-parseable success criteria. Use when you want automated eval harnesses to score results without human judgment. Keys are free-form. |
+| `difficulty` | string | --- | One of: `basic`, `intermediate`, `advanced`. |
+| `model_agnostic` | boolean | `true` | Whether the eval is designed to work across different LLMs. Set to `false` if it relies on model-specific capabilities. |
+| `notes` | string | --- | Additional context for eval runners --- known edge cases, expected variance, etc. |
+
+### Field Constraints
+
+- `prompt` must be non-empty.
+- `expected` must contain at least one criterion.
+- `tags` values should come from the [tag taxonomy](#tag-taxonomy) but custom tags are allowed.
+- `context_files` paths are relative to the skill's repository root.
+- `setup` commands run in a temporary directory. Do not assume persistent state.
+- `difficulty` must be one of `basic`, `intermediate`, `advanced` if present.
+
+---
+
+## Writing Good Prompts
+
+### Be Specific
+
+Bad:
+```yaml
+prompt: "Audit this repo."
+```
+
+Good:
+```yaml
+prompt: |
+  Scan the repository at /tmp/test-repo using the repo-audit
+  skill. Generate a Markdown readiness report covering all five
+  scan dimensions (Security, Code Quality, Documentation, Repo
+  Hygiene, Legal & Compliance). Include an overall verdict.
+```
+
+### Include Context the Agent Needs
+
+If the eval depends on a specific repository state, describe it or use `setup` to create it:
+
+```yaml
+setup: |
+  mkdir -p /tmp/test-repo
+  cd /tmp/test-repo && git init
+  echo "AWS_SECRET_KEY=AKIAIOSFODNN7EXAMPLE" > config.py
+  git add -A && git commit -m "init"
+prompt: |
+  Scan the repository at /tmp/test-repo for secrets.
+  The repo intentionally contains a hardcoded AWS key.
+```
+
+### Match the Consumption Model
+
+Write prompts that match how agents actually use the Skill:
+
+- **Model A (Script Execution)**: "Run `scripts/run_scan.sh /tmp/test-repo` and interpret the output."
+- **Model B (Knowledge-Driven)**: "Read the scan specification and perform the checks using your own tools."
+- **Model C (Hybrid)**: "Run the scan script, then review the findings and suggest remediations."
+
+---
+
+## Writing Good Success Criteria
+
+### Use Observable Outcomes
+
+Each `expected` item should describe something an evaluator can verify by reading the agent's output.
+
+Bad:
+```yaml
+expected:
+  - "The agent understands the report"
+```
+
+Good:
+```yaml
+expected:
+  - "Report contains an overall READY or NOT READY verdict"
+  - "Each finding includes file path, severity, and remediation"
+```
+
+### Be Exhaustive but Reasonable
+
+Cover the key outcomes without being so specific that normal LLM variation causes false failures:
+
+```yaml
+expected:
+  - "AWS_SECRET_KEY in config.py is identified as a CRITICAL finding"
+  - "Overall verdict is NOT READY"
+  - "Remediation suggests removing the key and rotating credentials"
+```
+
+### Use `expected_behavior` for Automation
+
+When evals will be scored by a harness rather than a human, add structured criteria:
+
+```yaml
+expected_behavior:
+  verdict: NOT_READY
+  must_find_files:
+    - config.py
+  minimum_critical_findings: 1
+```
+
+---
+
+## Tag Taxonomy
+
+| Tag | When to use |
+|-----|-------------|
+| `basic` | Core functionality, happy-path scenarios |
+| `intermediate` | Multi-step workflows, combined features |
+| `advanced` | Complex scenarios, edge cases requiring deep reasoning |
+| `happy-path` | Expected, common-case input |
+| `edge-case` | Unusual input, boundary conditions |
+| `regression` | Previously broken behavior that was fixed |
+| `security` | Security-related checks |
+| `knowledge-only` | Eval that uses Model B (no script execution) |
+| `script-execution` | Eval that uses Model A (script execution only) |
+| `hybrid` | Eval that uses Model C (scripts + knowledge) |
+| `web3` | Web3/blockchain-specific checks |
+
+Custom tags are allowed. Keep them lowercase, hyphen-separated.
+
+---
+
+## Examples
+
+### Script Execution Eval (Model A)
+
+```yaml
+prompt: |
+  Run the repo-audit scan script against /tmp/test-repo:
+    ./skills/repo-audit/scripts/run_scan.sh /tmp/test-repo
+  Report the overall verdict and list any CRITICAL findings.
+description: >
+  Verify the scan script produces correct output when executed
+  directly by the agent.
+tags:
+  - basic
+  - script-execution
+setup: |
+  mkdir -p /tmp/test-repo
+  cd /tmp/test-repo && git init
+  echo "# My Project" > README.md && echo "MIT" > LICENSE
+  git add -A && git commit -m "init"
+expected:
+  - "Script executes without errors"
+  - "Output contains a Markdown-formatted report"
+  - "Overall verdict is READY"
+difficulty: basic
+```
+
+### Knowledge-Driven Eval (Model B)
+
+```yaml
+prompt: |
+  Without running any scripts, read the repo-audit scan
+  specification and perform a manual security audit of the
+  repository at /tmp/test-repo. Report findings in the same
+  format as the scan script output.
+description: >
+  Verify that an agent can perform a comprehensive audit using
+  only the skill's documentation and its own tools.
+tags:
+  - intermediate
+  - knowledge-only
+context_files:
+  - skills/repo-audit/SKILL.md
+  - skills/repo-audit/references/SCAN_SPEC.md
+  - skills/repo-audit/references/REPORT_FORMAT.md
+setup: |
+  mkdir -p /tmp/test-repo
+  cd /tmp/test-repo && git init
+  echo "password = 's3cret'" > app.py
+  echo "# My App" > README.md
+  git add -A && git commit -m "init"
+expected:
+  - "Hardcoded password in app.py is identified"
+  - "Report covers all five scan dimensions"
+  - "Checks the agent cannot perform are marked SKIPPED"
+difficulty: intermediate
+```
+
+### Hybrid Eval (Model C)
+
+```yaml
+prompt: |
+  Run the repo-audit scan script on /tmp/test-repo, then review
+  the findings. For each CRITICAL or HIGH finding, provide a
+  specific remediation with code examples.
+description: >
+  Verify the agent can execute the scan and add value by
+  interpreting and extending the automated results.
+tags:
+  - intermediate
+  - hybrid
+setup: |
+  mkdir -p /tmp/test-repo
+  cd /tmp/test-repo && git init
+  echo "GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" > deploy.sh
+  echo "# Deploy" >> deploy.sh
+  chmod +x deploy.sh
+  git add -A && git commit -m "init"
+expected:
+  - "Scan script runs successfully"
+  - "GITHUB_TOKEN in deploy.sh is flagged as CRITICAL"
+  - "Remediation includes using environment variables or a secrets manager"
+  - "Code example shows how to replace the hardcoded token"
+difficulty: intermediate
+```
+
+---
+
+## File Naming
+
+Eval files follow the pattern `eval_<descriptive_name>.yaml`:
+
+- `eval_clean_repo_scan.yaml`
+- `eval_secrets_detected.yaml`
+- `eval_knowledge_driven_scan.yaml`
+
+Use snake_case for the descriptive name. This mirrors the `test_*.sh` convention in `tests/`.
+
+---
+
+## Running Evals
+
+Evals are **not** run in CI. They require an LLM and produce non-deterministic results.
+
+To run an eval manually:
+
+1. Execute the `setup` commands (if any) to prepare the environment.
+2. Load the `context_files` (if any) into the agent session.
+3. Give the agent the `prompt` verbatim.
+4. Compare the agent's output against each `expected` criterion.
+5. Score each criterion as pass or fail.
+
+A future eval harness may automate steps 2--5. The `expected_behavior` field supports this by providing structured, machine-parseable criteria.

--- a/EVAL_SPEC.md
+++ b/EVAL_SPEC.md
@@ -108,7 +108,7 @@ notes: >
 | `tags` | list of strings | `[]` | Classification tags from the [tag taxonomy](#tag-taxonomy). |
 | `context_files` | list of strings | `[]` | Paths (relative to repo root) the agent should load before executing. |
 | `setup` | string | --- | Shell commands to run before the eval to prepare the environment (create temp repos, seed data, etc.). |
-| `expected_behavior` | map | --- | Structured, machine-parseable success criteria. Use when you want automated eval harnesses to score results without human judgment. Keys are free-form. |
+| `expected_behavior` | map | --- | Structured, machine-parseable success criteria for automated eval harnesses. Keys are free-form. Only add this when building a harness that scores programmatically --- it should express the same intent as `expected`. |
 | `difficulty` | string | --- | One of: `basic`, `intermediate`, `advanced`. |
 | `model_agnostic` | boolean | `true` | Whether the eval is designed to work across different LLMs. Set to `false` if it relies on model-specific capabilities. |
 | `notes` | string | --- | Additional context for eval runners --- known edge cases, expected variance, etc. |
@@ -118,8 +118,8 @@ notes: >
 - `prompt` must be non-empty.
 - `expected` must contain at least one criterion.
 - `tags` values should come from the [tag taxonomy](#tag-taxonomy) but custom tags are allowed.
-- `context_files` paths are relative to the skill's repository root.
-- `setup` commands run in a temporary directory. Do not assume persistent state.
+- `context_files` paths are relative to the repository root.
+- `setup` commands must be self-cleaning. Use `rm -rf` at the top to remove prior state from the same eval.
 - `difficulty` must be one of `basic`, `intermediate`, `advanced` if present.
 
 ---

--- a/SKILL_GUIDE.md
+++ b/SKILL_GUIDE.md
@@ -398,7 +398,7 @@ Avoid abbreviations unless universally understood (`eks`, `ci-cd`, `aws`).
 - [ ] Skill added to `.claude-plugin/marketplace.json`
 - [ ] Tests exist (if scripts are included)
 - [ ] Tests pass locally
-- [ ] Evals exist for non-trivial skills (recommended)
+- [ ] Evals exist for non-trivial skills (optional, recommended)
 
 ---
 

--- a/SKILL_GUIDE.md
+++ b/SKILL_GUIDE.md
@@ -17,7 +17,8 @@ my-skill/
 ├── references/           # Optional — detailed documentation
 ├── assets/               # Optional — templates, images, data files
 ├── examples/             # Optional — example outputs
-└── tests/                # Optional (recommended) — test suite
+├── tests/                # Optional (recommended) — test suite
+└── evals/                # Optional — agent effectiveness evals
 ```
 
 Minimal valid `SKILL.md`:
@@ -277,6 +278,31 @@ Tests are not required by the Agent Skills standard but are strongly recommended
 
 See `skills/repo-audit/tests/` for a reference implementation.
 
+### Evals
+
+Tests validate that scripts work correctly. Evals validate that a Skill **as a whole** produces good outcomes when an agent uses it.
+
+| Property | `tests/` | `evals/` |
+|----------|----------|----------|
+| Validates | Script correctness | Skill effectiveness |
+| Deterministic? | Yes | No |
+| Runs in CI? | Yes | No |
+| Requires LLM? | No | Yes |
+| File pattern | `test_*.sh` | `eval_*.yaml` |
+
+Minimal eval file (`evals/eval_basic_scan.yaml`):
+
+```yaml
+prompt: |
+  Scan the repository at /tmp/test-repo and generate
+  a readiness report.
+expected:
+  - "Report contains an overall READY or NOT READY verdict"
+  - "All five scan dimensions appear in the summary"
+```
+
+See [EVAL_SPEC.md](EVAL_SPEC.md) for the full schema, optional fields, tag taxonomy, and examples.
+
 ### Three Consumption Models
 
 Nexus Skills are designed to work at multiple layers. When writing your SKILL.md, consider all three:
@@ -372,6 +398,7 @@ Avoid abbreviations unless universally understood (`eks`, `ci-cd`, `aws`).
 - [ ] Skill added to `.claude-plugin/marketplace.json`
 - [ ] Tests exist (if scripts are included)
 - [ ] Tests pass locally
+- [ ] Evals exist for non-trivial skills (recommended)
 
 ---
 

--- a/SKILL_TEMPLATE.md
+++ b/SKILL_TEMPLATE.md
@@ -40,3 +40,7 @@ metadata:
 ## Common Pitfalls
 
 - **Pitfall**: Description and how to avoid it.
+
+## Evals
+
+See [EVAL_SPEC.md](EVAL_SPEC.md) for the eval format. Add eval files to `evals/eval_*.yaml`.

--- a/SKILL_TEMPLATE.md
+++ b/SKILL_TEMPLATE.md
@@ -43,4 +43,4 @@ metadata:
 
 ## Evals
 
-See [EVAL_SPEC.md](EVAL_SPEC.md) for the eval format. Add eval files to `evals/eval_*.yaml`.
+See `EVAL_SPEC.md` in the repository root for the eval format. Add eval files to `evals/eval_*.yaml`.

--- a/skills/repo-audit/evals/eval_clean_repo_scan.yaml
+++ b/skills/repo-audit/evals/eval_clean_repo_scan.yaml
@@ -1,0 +1,30 @@
+prompt: |
+  Scan the repository at /tmp/eval-clean-repo using the
+  repo-audit skill. Run the scan script and generate a full
+  Markdown readiness report covering all five dimensions.
+description: >
+  Verify that a clean, well-structured repository receives a
+  READY verdict with no CRITICAL or HIGH findings.
+tags:
+  - basic
+  - happy-path
+context_files:
+  - skills/repo-audit/SKILL.md
+setup: |
+  rm -rf /tmp/eval-clean-repo
+  mkdir -p /tmp/eval-clean-repo
+  cd /tmp/eval-clean-repo && git init
+  echo "# My Project" > README.md
+  echo "MIT License" > LICENSE
+  echo "node_modules/" > .gitignore
+  mkdir -p src
+  echo "console.log('hello');" > src/index.js
+  git add -A && git commit -m "Initial commit"
+expected:
+  - "Overall verdict is READY"
+  - "Report includes all five scan dimensions: Security, Code Quality, Documentation, Repo Hygiene, Legal & Compliance"
+  - "No CRITICAL findings are reported"
+  - "No HIGH findings are reported"
+  - "Report is formatted as Markdown with a summary table"
+difficulty: basic
+model_agnostic: true

--- a/skills/repo-audit/evals/eval_clean_repo_scan.yaml
+++ b/skills/repo-audit/evals/eval_clean_repo_scan.yaml
@@ -8,6 +8,7 @@ description: >
 tags:
   - basic
   - happy-path
+  - script-execution
 context_files:
   - skills/repo-audit/SKILL.md
 setup: |

--- a/skills/repo-audit/evals/eval_false_positive_handling.yaml
+++ b/skills/repo-audit/evals/eval_false_positive_handling.yaml
@@ -1,0 +1,54 @@
+prompt: |
+  Scan the repository at /tmp/eval-false-positive-repo using
+  the repo-audit skill. The repository contains test fixtures
+  with intentional fake secrets. Review the findings and
+  distinguish real secrets from test fixtures. Note which
+  findings are likely false positives.
+description: >
+  Verify that the agent can identify and flag known
+  false-positive patterns -- such as example API keys in test
+  fixtures, placeholder credentials in documentation, and
+  dummy tokens in sample configs -- rather than treating them
+  as real security issues.
+tags:
+  - edge-case
+context_files:
+  - skills/repo-audit/SKILL.md
+setup: |
+  rm -rf /tmp/eval-false-positive-repo
+  mkdir -p /tmp/eval-false-positive-repo
+  cd /tmp/eval-false-positive-repo && git init
+  echo "# Secret Scanner Test Suite" > README.md
+  echo "MIT License" > LICENSE
+  echo "node_modules/" > .gitignore
+  mkdir -p tests/fixtures
+  cat > tests/fixtures/fake_secrets.py << 'PYEOF'
+  # Test fixtures -- these are intentionally fake
+  EXAMPLE_AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
+  EXAMPLE_SECRET = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+  PYEOF
+  cat > docs/setup.md << 'MDEOF'
+  ## Configuration
+
+  Replace the placeholder values below with your actual credentials:
+
+  ```
+  API_KEY=your-api-key-here
+  DB_PASSWORD=change-me
+  ```
+  MDEOF
+  mkdir -p src
+  echo "print('production code, no secrets')" > src/main.py
+  git add -A && git commit -m "Initial commit"
+expected:
+  - "Test fixture file tests/fixtures/fake_secrets.py is identified as containing secret-like patterns"
+  - "Agent notes that AKIAIOSFODNN7EXAMPLE is a known AWS example key, not a real credential"
+  - "Placeholder values in docs/setup.md are not flagged as real secrets"
+  - "Production code (src/main.py) is confirmed clean"
+  - "Overall assessment acknowledges false-positive patterns in test fixtures"
+difficulty: intermediate
+model_agnostic: true
+notes: >
+  False-positive handling depends on LLM judgment. The key
+  criterion is whether the agent distinguishes test fixtures
+  from real secrets, not whether it suppresses all warnings.

--- a/skills/repo-audit/evals/eval_false_positive_handling.yaml
+++ b/skills/repo-audit/evals/eval_false_positive_handling.yaml
@@ -21,22 +21,22 @@ setup: |
   echo "# Secret Scanner Test Suite" > README.md
   echo "MIT License" > LICENSE
   echo "node_modules/" > .gitignore
-  mkdir -p tests/fixtures
+  mkdir -p tests/fixtures docs
   cat > tests/fixtures/fake_secrets.py << 'PYEOF'
-  # Test fixtures -- these are intentionally fake
-  EXAMPLE_AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
-  EXAMPLE_SECRET = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-  PYEOF
+# Test fixtures -- these are intentionally fake
+EXAMPLE_AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
+EXAMPLE_SECRET = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+PYEOF
   cat > docs/setup.md << 'MDEOF'
-  ## Configuration
+## Configuration
 
-  Replace the placeholder values below with your actual credentials:
+Replace the placeholder values below with your actual credentials:
 
-  ```
-  API_KEY=your-api-key-here
-  DB_PASSWORD=change-me
-  ```
-  MDEOF
+```
+API_KEY=your-api-key-here
+DB_PASSWORD=change-me
+```
+MDEOF
   mkdir -p src
   echo "print('production code, no secrets')" > src/main.py
   git add -A && git commit -m "Initial commit"

--- a/skills/repo-audit/evals/eval_knowledge_driven_scan.yaml
+++ b/skills/repo-audit/evals/eval_knowledge_driven_scan.yaml
@@ -25,10 +25,10 @@ setup: |
   echo ".env" > .gitignore
   mkdir -p src
   cat > src/app.js << 'JSEOF'
-  // TODO: add error handling
-  const token = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef12";
-  console.log(token);
-  JSEOF
+// TODO: add error handling
+const token = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef12";
+console.log(token);
+JSEOF
   git add -A && git commit -m "Initial commit"
 expected:
   - "Report covers all five scan dimensions"

--- a/skills/repo-audit/evals/eval_knowledge_driven_scan.yaml
+++ b/skills/repo-audit/evals/eval_knowledge_driven_scan.yaml
@@ -1,0 +1,45 @@
+prompt: |
+  Without running any scripts, read the repo-audit scan
+  specification and perform a manual audit of the repository
+  at /tmp/eval-knowledge-repo. Use only your own tools (file
+  reading, grep, etc.) to check all five scan dimensions.
+  Produce a report in the same Markdown format as the scan
+  script output. Mark any checks you cannot perform as SKIPPED.
+description: >
+  Verify that an agent can perform a comprehensive audit using
+  only the skill documentation (Model B -- knowledge-driven),
+  without executing any scan scripts.
+tags:
+  - intermediate
+  - knowledge-only
+context_files:
+  - skills/repo-audit/SKILL.md
+  - skills/repo-audit/references/SCAN_SPEC.md
+  - skills/repo-audit/references/REPORT_FORMAT.md
+setup: |
+  rm -rf /tmp/eval-knowledge-repo
+  mkdir -p /tmp/eval-knowledge-repo
+  cd /tmp/eval-knowledge-repo && git init
+  echo "# TODO: write real readme" > README.md
+  echo "API_KEY=sk-test-1234567890" > .env
+  echo ".env" > .gitignore
+  mkdir -p src
+  cat > src/app.js << 'JSEOF'
+  // TODO: add error handling
+  const token = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef12";
+  console.log(token);
+  JSEOF
+  git add -A && git commit -m "Initial commit"
+expected:
+  - "Report covers all five scan dimensions"
+  - "Hardcoded GitHub token in src/app.js is identified"
+  - ".env file presence is noted even though it is gitignored"
+  - "TODO comments are flagged under Code Quality"
+  - "Checks requiring external tools (shellcheck, gitleaks, trivy) are marked SKIPPED"
+  - "Report follows the Markdown format from REPORT_FORMAT.md"
+difficulty: intermediate
+model_agnostic: true
+notes: >
+  Model B evals inherently have more variance than script-based
+  evals. Evaluators should focus on whether key findings are
+  identified rather than exact formatting matches.

--- a/skills/repo-audit/evals/eval_secrets_detected.yaml
+++ b/skills/repo-audit/evals/eval_secrets_detected.yaml
@@ -9,6 +9,7 @@ description: >
 tags:
   - basic
   - security
+  - script-execution
 context_files:
   - skills/repo-audit/SKILL.md
 setup: |
@@ -18,10 +19,10 @@ setup: |
   echo "# My Project" > README.md
   echo "MIT License" > LICENSE
   cat > config.py << 'PYEOF'
-  AWS_ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE"
-  AWS_SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-  DATABASE_URL = "postgres://admin:supersecret@db.example.com:5432/prod"
-  PYEOF
+AWS_ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE"
+AWS_SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+DATABASE_URL = "postgres://admin:supersecret@db.example.com:5432/prod"
+PYEOF
   echo "node_modules/" > .gitignore
   git add -A && git commit -m "Initial commit"
 expected:

--- a/skills/repo-audit/evals/eval_secrets_detected.yaml
+++ b/skills/repo-audit/evals/eval_secrets_detected.yaml
@@ -1,0 +1,34 @@
+prompt: |
+  Scan the repository at /tmp/eval-secrets-repo using the
+  repo-audit skill. The repository intentionally contains
+  hardcoded secrets. Run the scan and report all findings.
+description: >
+  Verify that repositories with hardcoded secrets receive a
+  NOT READY verdict with CRITICAL-severity findings that
+  identify the offending files and suggest remediations.
+tags:
+  - basic
+  - security
+context_files:
+  - skills/repo-audit/SKILL.md
+setup: |
+  rm -rf /tmp/eval-secrets-repo
+  mkdir -p /tmp/eval-secrets-repo
+  cd /tmp/eval-secrets-repo && git init
+  echo "# My Project" > README.md
+  echo "MIT License" > LICENSE
+  cat > config.py << 'PYEOF'
+  AWS_ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE"
+  AWS_SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+  DATABASE_URL = "postgres://admin:supersecret@db.example.com:5432/prod"
+  PYEOF
+  echo "node_modules/" > .gitignore
+  git add -A && git commit -m "Initial commit"
+expected:
+  - "Overall verdict is NOT READY"
+  - "config.py is identified as containing secrets"
+  - "AWS access key is flagged as CRITICAL severity"
+  - "Database URL with embedded password is flagged"
+  - "Remediation suggests using environment variables or a secrets manager"
+difficulty: basic
+model_agnostic: true

--- a/skills/repo-audit/evals/eval_web3_detection.yaml
+++ b/skills/repo-audit/evals/eval_web3_detection.yaml
@@ -12,6 +12,7 @@ tags:
   - basic
   - security
   - web3
+  - script-execution
 context_files:
   - skills/repo-audit/SKILL.md
 setup: |
@@ -23,19 +24,19 @@ setup: |
   echo "node_modules/" > .gitignore
   mkdir -p src
   cat > src/deploy.js << 'JSEOF'
-  const DEPLOYER_PRIVATE_KEY = "0x4c0883a69102937d6231471b5dbb6204fe512961708279f21a4c8e3b2ab5f801";
-  const MNEMONIC = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-  JSEOF
+const DEPLOYER_PRIVATE_KEY = "0x4c0883a69102937d6231471b5dbb6204fe512961708279f21a4c8e3b2ab5f801";
+const MNEMONIC = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+JSEOF
   cat > hardhat.config.js << 'JSEOF'
-  module.exports = {
-    networks: {
-      mainnet: {
-        url: "https://mainnet.infura.io/v3/YOUR_PROJECT_ID",
-        accounts: ["0x4c0883a69102937d6231471b5dbb6204fe512961708279f21a4c8e3b2ab5f801"]
-      }
+module.exports = {
+  networks: {
+    mainnet: {
+      url: "https://mainnet.infura.io/v3/YOUR_PROJECT_ID",
+      accounts: ["0x4c0883a69102937d6231471b5dbb6204fe512961708279f21a4c8e3b2ab5f801"]
     }
-  };
-  JSEOF
+  }
+};
+JSEOF
   git add -A && git commit -m "Initial commit"
 expected:
   - "Overall verdict is NOT READY"

--- a/skills/repo-audit/evals/eval_web3_detection.yaml
+++ b/skills/repo-audit/evals/eval_web3_detection.yaml
@@ -1,0 +1,47 @@
+prompt: |
+  Scan the repository at /tmp/eval-web3-repo using the
+  repo-audit skill. The repository is a Web3 project that
+  may contain blockchain-related secrets. Run the scan and
+  report all findings, paying special attention to Web3-specific
+  secret patterns.
+description: >
+  Verify that the scanner detects Web3-specific secret patterns
+  including Ethereum private keys, mnemonic seed phrases, and
+  Solana keypairs.
+tags:
+  - basic
+  - security
+  - web3
+context_files:
+  - skills/repo-audit/SKILL.md
+setup: |
+  rm -rf /tmp/eval-web3-repo
+  mkdir -p /tmp/eval-web3-repo
+  cd /tmp/eval-web3-repo && git init
+  echo "# DeFi Protocol" > README.md
+  echo "MIT License" > LICENSE
+  echo "node_modules/" > .gitignore
+  mkdir -p src
+  cat > src/deploy.js << 'JSEOF'
+  const DEPLOYER_PRIVATE_KEY = "0x4c0883a69102937d6231471b5dbb6204fe512961708279f21a4c8e3b2ab5f801";
+  const MNEMONIC = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+  JSEOF
+  cat > hardhat.config.js << 'JSEOF'
+  module.exports = {
+    networks: {
+      mainnet: {
+        url: "https://mainnet.infura.io/v3/YOUR_PROJECT_ID",
+        accounts: ["0x4c0883a69102937d6231471b5dbb6204fe512961708279f21a4c8e3b2ab5f801"]
+      }
+    }
+  };
+  JSEOF
+  git add -A && git commit -m "Initial commit"
+expected:
+  - "Overall verdict is NOT READY"
+  - "Ethereum private key (0x-prefixed hex) in src/deploy.js is flagged as CRITICAL"
+  - "Mnemonic seed phrase in src/deploy.js is flagged as CRITICAL"
+  - "Private key in hardhat.config.js accounts array is flagged"
+  - "Remediation suggests using environment variables or a hardware wallet for deployment keys"
+difficulty: basic
+model_agnostic: true


### PR DESCRIPTION
## Summary

- Add `EVAL_SPEC.md` defining a YAML-based format for agent-effectiveness evaluations that complement script-correctness tests
- Update `SKILL_GUIDE.md`, `SKILL_TEMPLATE.md`, and `AGENTS.md` with the `evals/` convention
- Add 5 example eval cases for `repo-audit` demonstrating the format across different scenarios (clean scan, secrets detection, knowledge-driven audit, false-positive handling, Web3 patterns)

Key distinction: `tests/` = script correctness (deterministic, CI, no LLM) vs `evals/` = skill effectiveness (non-deterministic, manual, requires LLM).

## Test plan

- [x] All eval YAML files have required fields (`prompt`, `expected`)
- [x] No Unicode box-drawing characters in any modified files
- [x] `EVAL_SPEC.md` link resolves from `SKILL_GUIDE.md`
- [x] Directory tree in `SKILL_GUIDE.md` has consistent formatting
- [ ] Review eval prompts and success criteria for clarity and completeness
- [ ] Verify YAML files parse with `yq` (not installed locally, validated structurally with Python)